### PR TITLE
corrects issue were nodes with same name mixed with other nodes at same level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+
+.idea

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ lazy val root = (project in file(".")).
     organization        := "org.micchon",
     scalaVersion        := Scala212,
     crossScalaVersions  := Scala212 :: Scala211 :: Scala210 :: Nil,
-    version             := "0.3.2",
+    version             := "0.3.3",
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "3.0.3" % Test
     ) ++ (

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val root = (project in file(".")).
     organization        := "org.micchon",
     scalaVersion        := Scala212,
     crossScalaVersions  := Scala212 :: Scala211 :: Nil,
-    version             := "0.4.1",
+    version             := "0.4.2",
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "3.0.3" % Test
     ) ++ (

--- a/src/main/scala/play/api/libs/json/Xml.scala
+++ b/src/main/scala/play/api/libs/json/Xml.scala
@@ -66,8 +66,11 @@ object Xml {
         if (isEmpty(n)) XLeaf((nameOf(n), XValue("")), buildAttrs(n)) :: Nil
         else if (isLeaf(n)) XLeaf((nameOf(n), XValue(n.text)), buildAttrs(n)) :: Nil
         else {
-          val children = directChildren(n)
-          XNode(buildAttrs(n) ::: children.map(nameOf).toList.zip(buildNodes(children))) :: Nil
+          val children = directChildren(n).map(cn ⇒ (nameOf(cn), buildNodes(cn).head))
+            .groupBy(_._1)
+            .map({ case (k,v) => (k,if (v.length > 1)  XArray(v.toList.map(_._2)) else v.head._2)})
+            .toList
+          XNode(buildAttrs(n) ::: children) :: Nil
         }
       case nodes: NodeSeq =>
         val allLabels = nodes.map(_.label)

--- a/src/test/scala/play/api/libs/json/PlayJsonXmlSpec.scala
+++ b/src/test/scala/play/api/libs/json/PlayJsonXmlSpec.scala
@@ -11,7 +11,7 @@ import scala.xml.{Elem, NodeSeq}
 class PlayJsonXmlSpec extends FlatSpec with Matchers {
 
   trait SetUp {
-    val xml: Elem =
+    val fruitXml: Elem =
       <fruits>
         <fruit>
           <name>Aubergine</name>
@@ -36,10 +36,10 @@ class PlayJsonXmlSpec extends FlatSpec with Matchers {
         <fruit price="5000" seeds="no" season="false" delicious="true">pineapple</fruit>
       </fruits>
 
-    val xmlNodeSeq: NodeSeq = <fruits><fruit><name>Aubergine</name><name>Eggplant</name></fruit><fruit><name>banana</name><price>1000</price><season>true</season><delicious>true</delicious></fruit><fruit><name><value>strawberry</value><colour>red</colour></name><price>3000</price><season>false</season><delicious>true</delicious></fruit><fruit><name>apple</name><price>500</price><seeds>yes</seeds><season>false</season><delicious>true</delicious></fruit><fruit><value>pineapple</value><price>5000</price><seeds>no</seeds><season>false</season><delicious>true</delicious></fruit></fruits>
+    val fruitXmlNodeSeq: NodeSeq = <fruits><fruit><name>Aubergine</name><name>Eggplant</name></fruit><fruit><name>banana</name><price>1000</price><season>true</season><delicious>true</delicious></fruit><fruit><name><value>strawberry</value><colour>red</colour></name><price>3000</price><season>false</season><delicious>true</delicious></fruit><fruit><name>apple</name><price>500</price><seeds>yes</seeds><season>false</season><delicious>true</delicious></fruit><fruit><value>pineapple</value><price>5000</price><seeds>no</seeds><season>false</season><delicious>true</delicious></fruit></fruits>
       .foldLeft(NodeSeq.Empty) { (a, b) => a ++ b }
 
-    val json: JsValue = Json.parse(
+    val fruitJson: JsValue = Json.parse(
       """
         |{
         |   "fruits":{
@@ -82,21 +82,72 @@ class PlayJsonXmlSpec extends FlatSpec with Matchers {
       """.stripMargin
     )
 
+    val vegetableXml: Elem =
+      <vegetables>
+        <vegetable>artichoke</vegetable>
+        <vegetable>broccoli</vegetable>
+        <vegetable>carrot</vegetable>
+        <not_a_vegetable>
+          <fruit>tomato</fruit>
+          <spice>salt</spice>
+          <spice>pepper</spice>
+        </not_a_vegetable>
+      </vegetables>
+
+    val vegetableXmlNodeSeq: NodeSeq = <vegetables><vegetable>artichoke</vegetable><vegetable>broccoli</vegetable><vegetable>carrot</vegetable><not_a_vegetable><fruit>tomato</fruit><spice>salt</spice><spice>pepper</spice></not_a_vegetable></vegetables>
+      .foldLeft(NodeSeq.Empty) { (a, b) => a ++ b }
+
+    val vegetableJson: JsValue = Json.parse(
+      """
+        |{
+        |   "vegetables":{
+        |      "vegetable":[
+        |         "artichoke",
+        |         "broccoli",
+        |         "carrot"
+        |      ],
+        |      "not_a_vegetable": {
+        |          "fruit": "tomato",
+        |          "spice": [
+        |             "salt",
+        |             "pepper"
+        |          ]
+        |      }
+        |   }
+        |}
+      """.stripMargin
+    )
   }
 
-  "toJson" should "convert xml to json" in new SetUp {
-    toJson(xml) should equal(json)
+  "toJson" should "convert fruit xml to json" in new SetUp {
+    toJson(fruitXml) should equal(fruitJson)
   }
 
-  "xml.toJson" should "convert xml to json implicitly" in new SetUp {
-    xml.toJson should equal(json)
+  "xml.toJson" should "convert fruit xml to json implicitly" in new SetUp {
+    fruitXml.toJson should equal(fruitJson)
   }
 
-  "toXml" should "convert json to xml" in new SetUp {
-    toXml(json) should equal(xmlNodeSeq)
+  "toXml" should "convert fruit json to xml" in new SetUp {
+    toXml(fruitJson) should equal(fruitXmlNodeSeq)
   }
 
-  "json.toXml" should "convert json to xml implicitly" in new SetUp {
-    json.toXml should equal(xmlNodeSeq)
+  "json.toXml" should "convert fruit json to xml implicitly" in new SetUp {
+    fruitJson.toXml should equal(fruitXmlNodeSeq)
+  }
+
+  "toJson" should "convert vegetable xml to json" in new SetUp {
+    toJson(vegetableXml) should equal(vegetableJson)
+  }
+
+  "xml.toJson" should "convert vegetable xml to json implicitly" in new SetUp {
+    vegetableXml.toJson should equal(vegetableJson)
+  }
+
+  "toXml" should "convert vegetable json to xml" in new SetUp {
+    toXml(vegetableJson) should equal(vegetableXmlNodeSeq)
+  }
+
+  "json.toXml" should "convert vegetable json to xml implicitly" in new SetUp {
+    vegetableJson.toXml should equal(vegetableXmlNodeSeq)
   }
 }

--- a/src/test/scala/play/api/libs/json/PlayJsonXmlSpec.scala
+++ b/src/test/scala/play/api/libs/json/PlayJsonXmlSpec.scala
@@ -5,13 +5,18 @@ import play.api.libs.json.Xml.toXml
 import play.api.libs.json.implicits.JsonXmlImplicits._
 import org.scalatest._
 import play.api.libs.json._
-import scala.xml.NodeSeq
+
+import scala.xml.{Elem, NodeSeq}
 
 class PlayJsonXmlSpec extends FlatSpec with Matchers {
 
   trait SetUp {
-    val xml =
+    val xml: Elem =
       <fruits>
+        <fruit>
+          <name>Aubergine</name>
+          <name>Eggplant</name>
+        </fruit>
         <fruit>
           <name>banana</name>
           <price>1000</price>
@@ -31,14 +36,17 @@ class PlayJsonXmlSpec extends FlatSpec with Matchers {
         <fruit price="5000" seeds="no" season="false" delicious="true">pineapple</fruit>
       </fruits>
 
-    val xmlNodeSeq: NodeSeq = <fruits><fruit><name>banana</name><price>1000</price><season>true</season><delicious>true</delicious></fruit><fruit><name><value>strawberry</value><colour>red</colour></name><price>3000</price><season>false</season><delicious>true</delicious></fruit><fruit><name>apple</name><price>500</price><seeds>yes</seeds><season>false</season><delicious>true</delicious></fruit><fruit><value>pineapple</value><price>5000</price><seeds>no</seeds><season>false</season><delicious>true</delicious></fruit></fruits>
+    val xmlNodeSeq: NodeSeq = <fruits><fruit><name>Aubergine</name><name>Eggplant</name></fruit><fruit><name>banana</name><price>1000</price><season>true</season><delicious>true</delicious></fruit><fruit><name><value>strawberry</value><colour>red</colour></name><price>3000</price><season>false</season><delicious>true</delicious></fruit><fruit><name>apple</name><price>500</price><seeds>yes</seeds><season>false</season><delicious>true</delicious></fruit><fruit><value>pineapple</value><price>5000</price><seeds>no</seeds><season>false</season><delicious>true</delicious></fruit></fruits>
       .foldLeft(NodeSeq.Empty) { (a, b) => a ++ b }
 
-    val json = Json.parse(
+    val json: JsValue = Json.parse(
       """
         |{
         |   "fruits":{
         |      "fruit":[
+        |         {
+        |           "name": [ "Aubergine", "Eggplant"]
+        |         },
         |         {
         |            "name":"banana",
         |            "price":1000,


### PR DESCRIPTION
Tests showed that the xml as defined by vegetableXml in PlayJsonXmlSpec would return only the last element for an array of values i.e. vegetable = carrot & spice = pepper and not an array of all values

This fix now tests directChildren and groups by node label to ensure correct array values applied