### PR TITLE
Ensure child nodes are created instead of combining values with parent

### DIFF
--- a/src/main/scala/play/api/libs/json/Xml.scala
+++ b/src/main/scala/play/api/libs/json/Xml.scala
@@ -57,7 +57,7 @@ object Xml {
 
     def mkFields(xs: List[(String, XElem)]): List[(String, JsValue)] =
       xs.flatMap { case (name, value) => (value, toJsValue(value)) match {
-        case (XLeaf(_, _ :: _), o: JsObject) => o.fields
+        case (XLeaf(_, _ :: _), o: JsObject) => Seq(name -> JsObject(o.fields))
         case (_, json) => Seq(name -> json)
       }}
 

--- a/src/main/scala/play/api/libs/json/Xml.scala
+++ b/src/main/scala/play/api/libs/json/Xml.scala
@@ -57,7 +57,9 @@ object Xml {
 
     def mkFields(xs: List[(String, XElem)]): List[(String, JsValue)] =
       xs.flatMap { case (name, value) => (value, toJsValue(value)) match {
-        case (XLeaf(_, _ :: _), o: JsObject) => Seq(name -> JsObject(o.fields))
+        case (XLeaf(_, _ :: _), o: JsObject) => 
+          if(o.fields.map(_._1).contains(name)) o.fields
+          else Seq(name -> o)
         case (_, json) => Seq(name -> json)
       }}
 


### PR DESCRIPTION
Resolves #5.

Creates expected output:

`{"users":{"user":[{"name":"David","id":2},{"name":"Harry","id":1}],"totalUsers":2}}`

Similarly in my use case which caused me to look into this:

`<schedule rid="201905227149575" uid="G49575" trainId="9T54" rsid="TL133300" ssd="2019-05-22" toc="TL" trainCat="XX">
    <a tpl="BRGHTN" act="TB" ptd="18:58" wtd="18:58" />
    <b tpl="PRSP" wtp="19:01" />
    <b tpl="HASOCKS" wtp="19:05" />
    <c tpl="OXFORD" wtp="19:20" />
</schedule>`

This would combine a and c and include their attributes in the schedule object, entirely losing the BRGHTN value in a/tpl like so:

`{"schedule":{"trainCat":"XX","toc":"TL","ssd":"2019-05-22","rsid":"TL133300","trainId":"9T54","uid":"G49575","rid":"201905227149575","b":[{"wtp":"19:01","tpl":"PRSP"},{"wtp":"19:05","tpl":"HASOCKS"}],"wtd":"18:58","ptd":"18:58","act":"TB","tpl":"OXFORD","wtp":"19:20"}}`

This change fixes that:

`{"schedule":{"trainCat":"XX","toc":"TL","ssd":"2019-05-22","rsid":"TL133300","trainId":"9T54","uid":"G49575","rid":"201905227149575","b":[{"wtp":"19:01","tpl":"PRSP"},{"wtp":"19:05","tpl":"HASOCKS"}],"a":{"wtd":"18:58","ptd":"18:58","act":"TB","tpl":"BRGHTN"},"c":{"wtp":"19:20","tpl":"OXFORD"}}}`