### PR TITLE
Updated dependencies for Scala 2.13 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It converts between play-json and xml like json4s.
 
 ## Install
 
-Builds are available for Scala 2.11.x and for 2.12.x. The main line of development of play-json-xml is 2.12.4.
+Builds are available for Scala 2.11.x, 2.12.x and for 2.13.x. The main line of development of play-json-xml is 2.12.4.
 
 ```scala
 libraryDependencies += "org.micchon" %% "play-json-xml" % "(version)"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It converts between play-json and xml like json4s.
 
 ## Install
 
-Builds are available for Scala 2.11.x, 2.12.x and for 2.13.x. The main line of development of play-json-xml is 2.12.4.
+Builds are available for 2.12.x and for 2.13.x. The main line of development of play-json-xml is 2.12.4.
 
 ```scala
 libraryDependencies += "org.micchon" %% "play-json-xml" % "(version)"

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+lazy val Scala213 = "2.13.0"
 lazy val Scala212 = "2.12.4"
 lazy val Scala211 = "2.11.11"
 
@@ -6,15 +7,15 @@ lazy val root = (project in file(".")).
     name                := "play-json-xml",
     organization        := "org.micchon",
     scalaVersion        := Scala212,
-    crossScalaVersions  := Scala212 :: Scala211 :: Nil,
+    crossScalaVersions  := Scala213 :: Scala212 :: Scala211 :: Nil,
     version             := "0.4.3-SNAPSHOT",
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "3.0.3" % Test
+      "org.scalatest" %% "scalatest" % "3.0.8" % Test
     ) ++ (
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, scalaMajor)) if scalaMajor >= 12 =>
-          Seq("org.scala-lang.modules" %% "scala-xml" % "1.0.6",
-              "com.typesafe.play" %% "play-json" % "2.7.1")
+          Seq("org.scala-lang.modules" %% "scala-xml" % "1.2.0",
+              "com.typesafe.play" %% "play-json" % "2.7.4")
         case Some((2, scalaMajor)) if scalaMajor >= 11 =>
           Seq("org.scala-lang.modules" %% "scala-xml" % "1.0.6",
               "com.typesafe.play" %% "play-json" % "2.5.13")

--- a/build.sbt
+++ b/build.sbt
@@ -1,27 +1,17 @@
 lazy val Scala213 = "2.13.0"
 lazy val Scala212 = "2.12.4"
-lazy val Scala211 = "2.11.11"
 
 lazy val root = (project in file(".")).
   settings(
     name                := "play-json-xml",
     organization        := "org.micchon",
     scalaVersion        := Scala212,
-    crossScalaVersions  := Scala213 :: Scala212 :: Scala211 :: Nil,
+    crossScalaVersions  := Scala213 :: Scala212 :: Nil,
     version             := "0.4.3-SNAPSHOT",
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "3.0.8" % Test
-    ) ++ (
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, scalaMajor)) if scalaMajor >= 12 =>
-          Seq("org.scala-lang.modules" %% "scala-xml" % "1.2.0",
-              "com.typesafe.play" %% "play-json" % "2.7.4")
-        case Some((2, scalaMajor)) if scalaMajor >= 11 =>
-          Seq("org.scala-lang.modules" %% "scala-xml" % "1.0.6",
-              "com.typesafe.play" %% "play-json" % "2.5.13")
-        case _ =>
-          Seq("com.typesafe.play" %% "play-json" % "2.4.11")
-      }
+      "org.scalatest" %% "scalatest" % "3.0.8" % Test,
+      "org.scala-lang.modules" %% "scala-xml" % "1.2.0",
+      "com.typesafe.play" %% "play-json" % "2.7.4"
     )
   ).
   settings(


### PR DESCRIPTION
Hello! I needed a build of your nice lib suitable for Scala 2.13, so I made one. If you want to support Scala 2.13, here is a very simple pull request.
You might wonder why scalatest dependency was updated. Old version had a stack depth problem in RefSpecLike and fixture.SpecLike under Scala 2.13, so just in case I upped the version.